### PR TITLE
Fix dependency issue for arm64/aarch64

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
         "downloadjs": "^1.4.7",
         "history": "^5.3.0",
         "html2canvas": "^1.4.1",
+        "imagemin-optipng": "^8.0.0",
+        "imagemin-pngquant": "^9.0.2",
         "lodash": "^4.17.21",
         "multer": "^1.4.4",
         "nprogress": "^0.2.0",


### PR DESCRIPTION
This patch fixes issues building on ARM-based platforms (e.g. Apple M1, Raspberry Pi)

I've also modifed the dockerfile to accommodate this change. See [the corresponding PR](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/pull/4) on RABIT-COMMON repo.

**Note:** on ARM, you **must** pass `CPPFLAGS="-DPNG_ARM_NEON_OPT=0"` environment variable when doing a local `npm install`, so the whole command looks like this:
```
$ CPPFLAGS="-DPNG_ARM_NEON_OPT=0" npm install
```
This will avoid the compile error. There's no need to do this when `docker-compose up` as it's already handled by the dockerfile.