### PR TITLE
feature/download-as-svg: Download as SVG

### DIFF
--- a/src/content/plots/CornerPlot.tsx
+++ b/src/content/plots/CornerPlot.tsx
@@ -7,6 +7,7 @@ import ContourPlot from './ContourPlot'
 import HistogramPlot from './HistogramPlot'
 import AxisX from './AxisX'
 import AxisY from './AxisY'
+import { NebulaFighterTheme } from '../../theme/schemes/NebulaFighterTheme'
 
 type ConerPlotPropType = {
     data: {
@@ -51,7 +52,11 @@ function CornerPlot({ data, parameters }: ConerPlotPropType) {
     }
 
     return (
-        <div id='corner-plot-id' className='corner-plot' style={{ width: 'min-content', backgroundColor: '#070C27' }}>
+        <div
+            id='corner-plot-id'
+            className='corner-plot'
+            style={{ width: 'min-content', backgroundColor: NebulaFighterTheme.palette.background.default }}
+        >
             {/* For each initial parameter, create a new row containing a Histogram of the 
             current parameter's data and contour plots for the intersections of the current
             parameter and all previous parameters. */}

--- a/src/content/plots/CornerPlot.tsx
+++ b/src/content/plots/CornerPlot.tsx
@@ -51,7 +51,7 @@ function CornerPlot({ data, parameters }: ConerPlotPropType) {
     }
 
     return (
-        <div className='corner-plot' style={{ width: 'min-content', backgroundColor: '#070C27' }}>
+        <div id='corner-plot-id' className='corner-plot' style={{ width: 'min-content', backgroundColor: '#070C27' }}>
             {/* For each initial parameter, create a new row containing a Histogram of the 
             current parameter's data and contour plots for the intersections of the current
             parameter and all previous parameters. */}

--- a/src/content/plots/PlotDownload.service.tsx
+++ b/src/content/plots/PlotDownload.service.tsx
@@ -1,0 +1,56 @@
+import downloadjs from 'downloadjs'
+import html2canvas from 'html2canvas'
+import * as d3 from 'd3'
+
+const PlotDownloadService = {
+    downloadAsPNG: async function () {
+        const cornerPlotElmt = document.querySelector<HTMLElement>('.corner-plot')
+        if (!cornerPlotElmt) return
+        changeColours('white', 'black')
+
+        const canvas = await html2canvas(cornerPlotElmt)
+        const dataURL = canvas.toDataURL('image/png')
+        downloadjs(dataURL, 'corner-plot.png', 'image/png')
+
+        changeColours('#070C27', 'white')
+    },
+    downloadAsSVG: function () {
+        const cornerPlotElmt = document.querySelector<HTMLElement>('.corner-plot')
+        changeColours('white', 'black')
+        var serializer = new XMLSerializer()
+        var source = serializer.serializeToString(cornerPlotElmt)
+
+        //add name spaces.
+        if (!source.match(/^<svg[^>]+xmlns="http\:\/\/www\.w3\.org\/2000\/svg"/)) {
+            source = source.replace(/^<svg/, '<svg xmlns="http://www.w3.org/2000/svg"')
+        }
+        if (!source.match(/^<svg[^>]+"http\:\/\/www\.w3\.org\/1999\/xlink"/)) {
+            source = source.replace(/^<svg/, '<svg xmlns:xlink="http://www.w3.org/1999/xlink"')
+        }
+
+        //add xml declaration
+        source = '<?xml version="1.0" standalone="no"?>\r\n' + source
+
+        //convert svg source to URI data scheme.
+        var url = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(source)
+
+        var downloadLink = document.createElement('a')
+        downloadLink.href = url
+        downloadLink.download = 'corner-plot.svg'
+        downloadLink.click()
+        changeColours('#070C27', 'white')
+    }
+}
+
+const changeColours = (backgroundColour, labelsColour) => {
+    const cornerPlotElmt = document.querySelector<HTMLElement>('.corner-plot')
+    cornerPlotElmt.style.backgroundColor = backgroundColour
+
+    let svg = d3.select('#corner-plot-id')
+    svg.selectAll('foreignObject').style('color', labelsColour)
+
+    d3.selectAll('.axis-lines').style('stroke', labelsColour)
+    d3.selectAll('.axis-labels').style('fill', labelsColour)
+}
+
+export default PlotDownloadService

--- a/src/content/plots/PlotDownload.service.tsx
+++ b/src/content/plots/PlotDownload.service.tsx
@@ -1,9 +1,10 @@
 import downloadjs from 'downloadjs'
 import html2canvas from 'html2canvas'
 import * as d3 from 'd3'
+import { NebulaFighterTheme } from '../../theme/schemes/NebulaFighterTheme'
 
 const PlotDownloadService = {
-    downloadAsPNG: async function () {
+    downloadAsPNG: async () => {
         const cornerPlotElmt = document.querySelector<HTMLElement>('.corner-plot')
         if (!cornerPlotElmt) return
         changeColours('white', 'black')
@@ -12,9 +13,9 @@ const PlotDownloadService = {
         const dataURL = canvas.toDataURL('image/png')
         downloadjs(dataURL, 'corner-plot.png', 'image/png')
 
-        changeColours('#070C27', 'white')
+        changeColours(NebulaFighterTheme.palette.background.default, 'white')
     },
-    downloadAsSVG: function () {
+    downloadAsSVG: () => {
         const cornerPlotElmt = document.querySelector<HTMLElement>('.corner-plot')
         changeColours('white', 'black')
         var serializer = new XMLSerializer()
@@ -38,7 +39,7 @@ const PlotDownloadService = {
         downloadLink.href = url
         downloadLink.download = 'corner-plot.svg'
         downloadLink.click()
-        changeColours('#070C27', 'white')
+        changeColours(NebulaFighterTheme.palette.background.default, 'white')
     }
 }
 

--- a/src/content/plots/PlotsPage.tsx
+++ b/src/content/plots/PlotsPage.tsx
@@ -2,9 +2,8 @@ import { MathJaxContext } from 'better-react-mathjax'
 import { useCallback, useState } from 'react'
 import CheckboxDropdown from '../pages/FileUpload/CheckboxDropdown'
 import CornerPlot from './CornerPlot'
-import downloadjs from 'downloadjs'
-import html2canvas from 'html2canvas'
 import { Button } from '@mui/material'
+import PlotDownloadService from './PlotDownload.service'
 
 function PlotsPage({ file }) {
     /* 
@@ -30,14 +29,13 @@ function PlotsPage({ file }) {
         }
     }
 
-    // Function for corner plot image download.
-    const downloadCornerPlotImage = async () => {
-        const cornerPlotElmt = document.querySelector<HTMLElement>('.corner-plot')
-        if (!cornerPlotElmt) return
+    // Functions for corner plot image download.
+    const downloadCornerPlotPNG = async () => {
+        PlotDownloadService.downloadAsPNG()
+    }
 
-        const canvas = await html2canvas(cornerPlotElmt)
-        const dataURL = canvas.toDataURL('image/png')
-        downloadjs(dataURL, 'corner-plot.png', 'image/png')
+    const downloadCornerPlotSVG = async () => {
+        PlotDownloadService.downloadAsSVG()
     }
 
     return (
@@ -50,8 +48,11 @@ function PlotsPage({ file }) {
                     sx={{ margin: '2rem 0 2rem 0' }}
                 />
                 <CornerPlot data={data} parameters={parameters} />
-                <Button variant='contained' onClick={downloadCornerPlotImage}>
-                    Download Image
+                <Button variant='contained' onClick={downloadCornerPlotPNG}>
+                    Download as PNG
+                </Button>
+                <Button variant='contained' onClick={downloadCornerPlotSVG}>
+                    Download as SVG
                 </Button>
             </MathJaxContext>
         </div>

--- a/src/content/plots/d3/AxisXD3.tsx
+++ b/src/content/plots/d3/AxisXD3.tsx
@@ -13,6 +13,7 @@ const create = (el, layout, domain, label) => {
     svg.append('foreignObject')
         .attr('width', layout.width)
         .attr('height', layout.axis.size)
+        .style('color', 'white')
         .append('xhtml:div')
         .style('height', '100%')
         .style('display', 'flex')
@@ -27,10 +28,12 @@ const create = (el, layout, domain, label) => {
         .range([0, layout.width - 1])
 
     // Add scales to axis
-    const x_axis = d3.axisBottom(scale).ticks(layout.axis.ticks).tickSize(layout.axis.tickSize)
+    const x_axis = svg.append('g').call(d3.axisBottom(scale).ticks(layout.axis.ticks).tickSize(layout.axis.tickSize))
 
-    // Append group and insert axis
-    svg.append('g').call(x_axis)
+    // Explicitly colour the axis so they display correctly when downloaded
+    x_axis.selectAll('line').style('stroke', 'white').classed('axis-lines', true)
+    x_axis.selectAll('path').style('stroke', 'white').classed('axis-lines', true)
+    x_axis.selectAll('text').style('fill', 'white').classed('axis-labels', true)
 }
 
 const destroy = el => {

--- a/src/content/plots/d3/AxisYD3.tsx
+++ b/src/content/plots/d3/AxisYD3.tsx
@@ -15,6 +15,7 @@ const create = (el, layout, domain, label) => {
         .attr('width', layout.height)
         .attr('height', layout.axis.size)
         .attr('transform', `rotate(-90), translate(${-layout.height}, 0)`)
+        .style('color', 'white')
         .append('xhtml:div')
         .style('height', '100%')
         .style('display', 'flex')
@@ -29,10 +30,15 @@ const create = (el, layout, domain, label) => {
         .range([layout.height - 1, 0])
 
     // Add scales to axis
-    const y_axis = d3.axisLeft(scale).ticks(layout.axis.ticks).tickSize(layout.axis.tickSize)
+    const y_axis = svg
+        .append('g')
+        .attr('transform', `translate(${layout.axis.size}, 0)`)
+        .call(d3.axisLeft(scale).ticks(layout.axis.ticks).tickSize(layout.axis.tickSize))
 
-    // Append group and insert axis
-    svg.append('g').attr('transform', `translate(${layout.axis.size}, 0)`).call(y_axis)
+    // Explicitly colour the axis so they display correctly when downloaded
+    y_axis.selectAll('line').style('stroke', 'white').classed('axis-lines', true)
+    y_axis.selectAll('path').style('stroke', 'white').classed('axis-lines', true)
+    y_axis.selectAll('text').style('fill', 'white').classed('axis-labels', true)
 }
 
 const destroy = el => {


### PR DESCRIPTION
Download as SVG implemented. Download logic moved to its own service. Colour fix made, but with a slightly hacky solution (colours are manually updated for a split second on download and then reversed). Can revisit this if it proves unsatisfactory or if anyone has better ideas.