### PR TITLE
Distinguish between local and Nectar production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "scripts": {
         "start": "webpack-dev-server --mode=development --env backend=local",
         "startNectar": "webpack-dev-server --mode=development --env backend=online",
-        "build": "webpack --mode=production --env backend=online",
+        "build": "webpack --mode=production --env backend=local",
+        "buildNectar": "webpack --mode=production --env backend=online",
         "openProd": "npx concurrently \"npx serve -s dist\" \"npm run openDev\"",
         "openDev": "start http://localhost:3000",
         "prettyAll": "npx prettier --write .",


### PR DESCRIPTION
To ensure that docker builds are working and consistency with the dev scripts (`npm run start` and `npm run startNectar`), I've moved `build` to `buildNectar` and add a new script `build` which uses local backend.