### PR TITLE
Added a fix for blur radius breaking share links

### DIFF
--- a/src/content/plots/Appearance/DatasetConfiguration.tsx
+++ b/src/content/plots/Appearance/DatasetConfiguration.tsx
@@ -54,7 +54,7 @@ function DatasetConfiguration({
         setIsSaved(false)
         setNewDataset(prevState => ({
             ...prevState,
-            blur_radius: new_blur_radius
+            blur_radius: +new_blur_radius
         }))
     }
 


### PR DESCRIPTION
When blur radius was updated, it was setting the value to be a string instead of a number. It is now correctly setting a number