### PR TITLE
Fix for plot share button and login/signup routes

### DIFF
--- a/src/content/Auth/UserProvider.tsx
+++ b/src/content/Auth/UserProvider.tsx
@@ -33,7 +33,7 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
             response => {
                 setjwt(response.data.jwt)
                 localStorage.setItem('jwt', response.data.jwt)
-                navigate('/management/profile')
+                navigate('/upload')
             },
             error => {
                 console.log(error)
@@ -61,7 +61,7 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
             response => {
                 setjwt(response.data.jwt)
                 localStorage.setItem('jwt', jwt)
-                navigate('/management/profile')
+                navigate('/upload')
             },
             error => {
                 console.log(error)

--- a/src/content/pages/account/login/index.tsx
+++ b/src/content/pages/account/login/index.tsx
@@ -105,7 +105,7 @@ const LoginForm = () => {
     //If jwt alrdy in local storage, render profile page
     if (enforceLogin()){
         useEffect(() => {
-            navigate('/management/profile')
+            navigate('/upload')
     })
     }
 

--- a/src/content/plots/PlotUploadShare.ts
+++ b/src/content/plots/PlotUploadShare.ts
@@ -2,35 +2,37 @@ import api from '../../api'
 import { PlotConfig, DatasetConfig, ParameterConfig } from './PlotTypes'
 
 export const uploadCornerPlotConfigs = async (
-    collectionId: string,
-    plotConfig: PlotConfig,
-    datasetConfigs: DatasetConfig[],
-    parameterConfigs: ParameterConfig[]
+  collectionId: string,
+  plotConfig: PlotConfig,
+  datasetConfigs: DatasetConfig[],
+  parameterConfigs: ParameterConfig[]
 ): Promise<string> => {
-    // TODO: update this to work with firebase login,
-    // or otherwise to whatever temporary/default user ID is in Nectar
-    const userId = 'temp'
+  // TODO: update this to work with firebase login,
+  // or otherwise to whatever temporary/default user ID is in Nectar
+  const userId = 'temp'
 
-    const reqBody = {
-        user_id: userId,
-        collection_id: collectionId,
-        plot_config: plotConfig,
-        dataset_configs: removeRawDataFromConfigs(datasetConfigs),
-        parameters: addFileIdToParams(parameterConfigs, datasetConfigs[0].file_id)
-    }
+  const reqBody = {
+    user_id: userId,
+    collection_id: collectionId,
+    plot_config: plotConfig,
+    dataset_configs: removeRawDataFromConfigs(datasetConfigs),
+    parameters: addFileIdToParams(parameterConfigs, datasetConfigs[0].file_id)
+  }
 
-    return await (await api.post('/plot', reqBody)).data
+  return await (
+    await api.post('/plot', reqBody)
+  ).data.cornerPlotId
 }
 
 const removeRawDataFromConfigs = (datasetConfigs: DatasetConfig[]) => {
-    return datasetConfigs.map(datasetConfig => {
-        const { data, ...config } = datasetConfig
-        return config
-    })
+  return datasetConfigs.map(datasetConfig => {
+    const { data, ...config } = datasetConfig
+    return config
+  })
 }
 
 const addFileIdToParams = (parameterConfigs: ParameterConfig[], file_id: string) => {
-    return parameterConfigs.map(parameterConfig => {
-        return { file_id: file_id, ...parameterConfig }
-    })
+  return parameterConfigs.map(parameterConfig => {
+    return { file_id: file_id, ...parameterConfig }
+  })
 }

--- a/src/content/plots/PlotsPage.tsx
+++ b/src/content/plots/PlotsPage.tsx
@@ -67,6 +67,7 @@ function PlotsPage({
   const [parameters, setParameters] = useState<ParameterConfig[]>([])
   const [config, setConfig] = useState<PlotConfig>(PlotConfigDefault)
   const [open, setOpen] = useState(false)
+  const [snackbarMessage, setSnackbarMessage] = useState<string>('')
 
   useEffect(() => {
     setDatasets(
@@ -114,11 +115,13 @@ function PlotsPage({
   const sharePlot = async () => {
     try {
       const shareResponse = await uploadCornerPlotConfigs(id, config, datasets, parameters)
-      navigator.clipboard.writeText(constructShareLink(shareResponse.cornerPlotId))
+      navigator.clipboard.writeText(constructShareLink(shareResponse))
+      setSnackbarMessage('Link copied to clipboard')
       setOpen(true)
     } catch (err) {
       console.error(err)
-      setShareLink('Link could not be generated')
+      setSnackbarMessage('Link could not be generated')
+      setOpen(true)
     }
   }
 
@@ -145,7 +148,7 @@ function PlotsPage({
                     Generate Shareable Link
                   </Button>
                   <Snackbar
-                    message='Link copied to clibboard'
+                    message={snackbarMessage}
                     anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                     autoHideDuration={2000}
                     onClose={() => setOpen(false)}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -61,7 +61,7 @@ const routes: RouteObject[] = [
     children: [
       {
         path: '',
-        element: <Navigate to='/management/profile' replace />
+        element: <Navigate to='/upload' replace />
       },
       {
         path: 'profile',


### PR DESCRIPTION
In addition to making a minor improvement to the share plot button, logging in or signing up now navigates the user to the upload page by default