### PR TITLE
Bug/replace all

### DIFF
--- a/src/content/plots/constants/LaTeX.tsx
+++ b/src/content/plots/constants/LaTeX.tsx
@@ -1,4 +1,4 @@
-export const default_translation = (parameter_name: string): string => parameter_name.replace('_', ' ')
+export const default_translation = (parameter_name: string): string => parameter_name.replaceAll('_', ' ')
 
 export const latex_translations = {
     "chirp_mass": "$\\mathcal{M}$",


### PR DESCRIPTION
Fix a bug with the current LaTeX rendering where replacing of _'s only replaced the first one.