### PR TITLE
updated color scale on color picker

### DIFF
--- a/src/content/plots/constants/Colours.tsx
+++ b/src/content/plots/constants/Colours.tsx
@@ -1,9 +1,20 @@
 export const colours = {
-    plotDefault: '#0088FF',
-    plotBackground: 'white',
-    appearanceConfigBackground: '#111633',
-    pickerBackground: '#1B2038',
-    axesColour: 'white',
-    plotBorder: '1px solid black',
-    colourPickerOptions: ['#0088FF', '#BF40BF', '#069F00', '#BC0000', '#FF8921', '#919191', '#FFB61E', '#000000', '#FF0074', '#001BAA']
+  plotDefault: '#0088FF',
+  plotBackground: 'white',
+  appearanceConfigBackground: '#111633',
+  pickerBackground: '#1B2038',
+  axesColour: 'white',
+  plotBorder: '1px solid black',
+  colourPickerOptions: [
+    '#BC0000',
+    '#FF0074',
+    '#FF8921',
+    '#FFB61E',
+    '#069F00',
+    '#0088FF',
+    '#001BAA',
+    '#BF40BF',
+    '#919191',
+    '#000000'
+  ]
 }


### PR DESCRIPTION
simple reordering of color scale for color picker. Color are in the format ROYGB

old:
<img width="430" alt="image" src="https://user-images.githubusercontent.com/51845347/195264675-08c794ce-f524-4609-929c-3002b04dfb8f.png">

new:
<img width="254" alt="image" src="https://user-images.githubusercontent.com/51845347/195265307-78645d4d-bad9-42de-a542-d9eda448679d.png">
